### PR TITLE
Making ansible ssh user optional in aws terrraform.

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -232,9 +232,11 @@ def aws_host(resource, module_name):
                                              'vpc_security_group_ids'),
         # ansible-specific
         'ansible_ssh_port': 22,
-        'ansible_ssh_user': raw_attrs['tags.sshUser'],
         'ansible_ssh_host': raw_attrs['public_ip'],
     }
+
+    if 'tags.sshUser' in raw_attrs:
+        attrs['ansible_ssh_user'] = raw_attrs['tags.sshUser']
 
     # attrs specific to microservices-infrastructure
     attrs.update({


### PR DESCRIPTION
Making ansible ssh user optional in aws terrraform so it could be specified using different approach.