### PR TITLE
default root to TERRAFORM_STATE_ROOT env var if set

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -373,8 +373,9 @@ def main():
     parser.add_argument('--nometa',
                         action='store_true',
                         help='with --list, exclude hostvars')
-    default_root = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                '..', '..', ))
+    default_root = os.environ.get('TERRAFORM_STATE_ROOT',
+                                  os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                               '..', '..', )))
     parser.add_argument('--root',
                         default=default_root,
                         help='custom root to search for `.tfstate`s in')


### PR DESCRIPTION
allow the root directory in which to search for tfstate files to be read from the environment. This is useful when you want to keep the terraform state out of the same directory in which you are running ansible.