### PR TITLE
Add support for SoftLayer

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -193,6 +193,43 @@ def digitalocean_host(resource, tfvars=None):
     return name, attrs, groups
 
 
+@parses('softlayer_virtualserver')
+@calculate_mi_vars
+def softlayer_host(resource, module_name):
+    raw_attrs = resource['primary']['attributes']
+    name = raw_attrs['name']
+    groups = []
+
+    attrs = {
+        'id': raw_attrs['id'],
+        'image': raw_attrs['image'],
+        'ipv4_address': raw_attrs['ipv4_address'],
+        'metadata': json.loads(raw_attrs['user_data']),
+        'region': raw_attrs['region'],
+        'ram': raw_attrs['ram'],
+        'cpu': raw_attrs['cpu'],
+        'ssh_keys': parse_list(raw_attrs, 'ssh_keys'),
+        'public_ipv4': raw_attrs['ipv4_address'],
+        'private_ipv4': raw_attrs['ipv4_address_private'],
+        'ansible_ssh_host': raw_attrs['ipv4_address'],
+        'ansible_ssh_port': 22,
+        'ansible_ssh_user': 'root',
+        'provider': 'softlayer',
+    }
+
+    # attrs specific to microservices-infrastructure
+    attrs.update({
+        'consul_dc': _clean_dc(attrs['metadata'].get('dc', attrs['region'])),
+        'role': attrs['metadata'].get('role', 'none')
+    })
+
+    # groups specific to microservices-infrastructure
+    groups.append('role=' + attrs['role'])
+    groups.append('dc=' + attrs['consul_dc'])
+
+    return name, attrs, groups
+
+
 @parses('openstack_compute_instance_v2')
 @calculate_mi_vars
 def openstack_host(resource, module_name):

--- a/tests/test_softlayer.py
+++ b/tests/test_softlayer.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+@pytest.fixture
+def softlayer_host():
+    from terraform import softlayer_host
+    return softlayer_host
+
+@pytest.fixture
+def softlayer_resource():
+    return {
+        "type": "softlayer_virtualserver",
+        "primary": {
+            "id": "12345678",
+            "attributes": {
+                "cpu": 1,
+                "domain": "example.com",
+                "id": "12345678",
+                "image": "CENTOS_7_64",
+                "ipv4_address": "1.2.3.4",
+                "ipv4_address_private": "5.6.7.8",
+                "name": "mi-control-01",
+                "public_network_speed": "1000",
+                "ram": "4096",
+                "region": "ams01",
+                "ssh_keys.#": "1",
+                "ssh_keys.0": "23456",
+                "user_data": "{\"role\":\"control\",\"dc\":\"mi\"}"
+            }
+        }
+    }
+
+def test_name(softlayer_resource, softlayer_host):
+    name, _, _ = softlayer_host(softlayer_resource, '')
+    assert name == "mi-control-01"
+
+@pytest.mark.parametrize('attr,should', {
+    'id': '12345678',
+    'image': 'CENTOS_7_64',
+    'ipv4_address': '1.2.3.4',
+    'metadata': {'role': 'control', 'dc': 'mi'},
+    'region': 'ams01',
+    'ram': '4096',
+    'cpu': 1,
+    'ssh_keys': ['23456'],
+    # ansible
+    'ansible_ssh_host': '1.2.3.4',
+    'ansible_ssh_port': 22,
+    'ansible_ssh_user': 'root',
+    # generic
+    'public_ipv4': '1.2.3.4',
+    'private_ipv4': '5.6.7.8',
+    'provider': 'softlayer',
+    # mi
+    'consul_dc': 'mi',
+    'role': 'control',
+}.items())
+def test_attrs(softlayer_resource, softlayer_host, attr, should):
+    _, attrs, _ = softlayer_host(softlayer_resource, 'module_name')
+    assert attr in attrs
+    assert attrs[attr] == should
+
+
+@pytest.mark.parametrize(
+    'group', ['dc=mi', 'role=control']
+)
+def test_groups(softlayer_resource, softlayer_host, group):
+    _, _, groups = softlayer_host(softlayer_resource, 'module_name')
+    assert group in groups


### PR DESCRIPTION
This will let us parse output from Terraform after having created virtual guest machines on SoftLayer.

Granted, the SoftLayer support in Terraform hasn't landed yet (https://github.com/hashicorp/terraform/pull/2554) but I can see no harm in supporting this in terraform.py anyways. Users of SoftLayer just need to be aware that they must run Terraform with a custom build that has all the SoftLayer stuff.

If you accept this change, do you want me to open a PR against microservices-infrastructure as well, to copy the script over? Or will you update it?
