### PR TITLE
Add ability to SSH to AWS instance via private IP

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -332,6 +332,8 @@ def aws_host(resource, module_name):
     # attrs specific to Ansible
     if 'tags.sshUser' in raw_attrs:
         attrs['ansible_ssh_user'] = raw_attrs['tags.sshUser']
+    if 'tags.sshPrivateIp' in raw_attrs:
+        attrs['ansible_ssh_host'] = raw_attrs['private_ip']
 
     # attrs specific to Mantl
     attrs.update({


### PR DESCRIPTION
Given an AWS instance that has both public and private IPs, allow for
specifying which IP address to set as the value for 'ansible_ssh_host' by
providing an checking for an optional instance tag 'sshPrivateIp'.