### PR TITLE
Updated terraform.py to set the private_ipv4 for all Vsphere hosts

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -442,6 +442,7 @@ def vsphere_host(resource, module_name):
         'id': raw_attrs['id'],
         'ip_address': raw_attrs['ip_address'],
         'private_ipv4': raw_attrs['ip_address'],
+        'public_ipv4': raw_attrs['ip_address'],
         'metadata': parse_dict(raw_attrs, 'configuration_parameters'),
         'ansible_ssh_port': 22,
         'provider': 'vsphere',

--- a/terraform.py
+++ b/terraform.py
@@ -441,6 +441,7 @@ def vsphere_host(resource, module_name):
     attrs = {
         'id': raw_attrs['id'],
         'ip_address': raw_attrs['ip_address'],
+        'private_ipv4': raw_attrs['ip_address'],
         'metadata': parse_dict(raw_attrs, 'configuration_parameters'),
         'ansible_ssh_port': 22,
         'provider': 'vsphere',


### PR DESCRIPTION
Some of the ansible roles like docker require this for all hosts in the inventory.