### PR TITLE
vSphere 6 IPv4 Update

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -444,23 +444,23 @@ def vsphere_host(resource, module_name):
     raw_attrs = resource['primary']['attributes']
     network_attrs = parse_dict(raw_attrs, 'network_interface')
     network = parse_dict(network_attrs, '0')
+    ip_address = network.get('ipv4_address', network['ip_address'])
     name = raw_attrs['name']
-
     groups = []
 
     attrs = {
         'id': raw_attrs['id'],
-        'ip_address': network['ipv4_address'],
-        'private_ipv4': network['ipv4_address'],
-        'public_ipv4': network['ipv4_address'],
-        'metadata': parse_dict(raw_attrs, 'configuration_parameters'),
+        'ip_address': ip_address,
+        'private_ipv4': ip_address,
+        'public_ipv4': ip_address,
+        'metadata': parse_dict(raw_attrs, 'custom_configuration_parameters'),
         'ansible_ssh_port': 22,
         'provider': 'vsphere',
     }
 
     try:
         attrs.update({
-            'ansible_ssh_host': network['ipv4_address'],
+            'ansible_ssh_host': ip_address,
         })
     except (KeyError, ValueError):
         attrs.update({'ansible_ssh_host': '', })

--- a/terraform.py
+++ b/terraform.py
@@ -442,14 +442,17 @@ def gce_host(resource, module_name):
 @calculate_mi_vars
 def vsphere_host(resource, module_name):
     raw_attrs = resource['primary']['attributes']
+    network_attrs = parse_dict(raw_attrs, 'network_interface')
+    network = parse_dict(network_attrs, '0')
     name = raw_attrs['name']
+
     groups = []
 
     attrs = {
         'id': raw_attrs['id'],
-        'ip_address': raw_attrs['ip_address'],
-        'private_ipv4': raw_attrs['ip_address'],
-        'public_ipv4': raw_attrs['ip_address'],
+        'ip_address': network['ipv4_address'],
+        'private_ipv4': network['ipv4_address'],
+        'public_ipv4': network['ipv4_address'],
         'metadata': parse_dict(raw_attrs, 'configuration_parameters'),
         'ansible_ssh_port': 22,
         'provider': 'vsphere',
@@ -457,7 +460,7 @@ def vsphere_host(resource, module_name):
 
     try:
         attrs.update({
-            'ansible_ssh_host': raw_attrs['ip_address'],
+            'ansible_ssh_host': network['ipv4_address'],
         })
     except (KeyError, ValueError):
         attrs.update({'ansible_ssh_host': '', })

--- a/tests/test_vsphere.py
+++ b/tests/test_vsphere.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+@pytest.fixture
+def vsphere_host():
+    from terraform import vsphere_host
+    return vsphere_host
+
+@pytest.fixture
+def vsphere_resource():
+    return {
+        "type": "vsphere_virtual_machine",
+        "primary": {
+            "id": "12345678",
+            "attributes": {
+                "custom_configuration_parameters.#": "4",
+                "custom_configuration_parameters.python_bin": "/usr/bin/python",
+                "custom_configuration_parameters.role": "control",
+                "custom_configuration_parameters.ssh_user": "vsphere-user",
+                "custom_configuration_parameters.consul_dc": "module_name",
+                "disk.#": "1",
+                "disk.0.datastore": "main01",
+                "disk.0.iops": "0",
+                "disk.0.size": "0",
+                "disk.0.template": "centos7-base",
+                "domain": "domain.com",
+                "id": "server01",
+                "memory": "2048",
+                "name": "mi-control-01",
+                "network_interface.#": "1",
+                "network_interface.0.adapter_type": "",
+                "network_interface.0.ip_address": "5.6.7.8",
+                "network_interface.0.ipv4_address": "1.2.3.4",
+                "network_interface.0.ipv4_prefix_length": "24",
+                "network_interface.0.ipv6_address": "",
+                "network_interface.0.ipv6_prefix_length": "64",
+                "network_interface.0.label": "VM Network",
+                "network_interface.0.subnet_mask": "",
+                "time_zone": "Etc/UTC",
+                "vcpu": "1"
+            }
+        }
+    }
+
+def test_name(vsphere_resource, vsphere_host):
+    name, _, _ = vsphere_host(vsphere_resource, '')
+    assert name == "mi-control-01"
+
+@pytest.mark.parametrize('attr,should', {
+    'id': 'server01',
+    # ansible
+    'ansible_ssh_host': '1.2.3.4',
+    'ansible_ssh_port': 22,
+    'ansible_ssh_user': 'vsphere-user',
+    'ansible_python_interpreter': '/usr/bin/python',
+    # generic
+    'public_ipv4': '1.2.3.4',
+    'private_ipv4': '1.2.3.4',
+    'provider': 'vsphere',
+    # mi
+    'consul_dc': 'module_name',
+    'role': 'control',
+}.items())
+def test_attrs(vsphere_resource, vsphere_host, attr, should):
+    _, attrs, _ = vsphere_host(vsphere_resource, 'module_name')
+    assert attr in attrs
+    assert attrs[attr] == should


### PR DESCRIPTION
vSphere has begun nesting information differently. This has resulted in the dynamic provider not working. This may already be addressed or this may just be in my case. I had corrected it for a vSphere6 and thought I would make a PR. I am not great at python, so this may not be the best way to solve it. 

Here is the data output as I am seeing it from terraform:
```
vsphere_virtual_machine.web1:
  #.....
  network_interface.# = 1
  network_interface.0.adapter_type =
  network_interface.0.ip_address =
  network_interface.0.ipv4_address = 192.168.66.22
  network_interface.0.ipv4_prefix_length = 24
  network_interface.0.ipv6_address = fe80::250:56ff:feb0:79dd
  network_interface.0.ipv6_prefix_length = 64
  network_interface.0.label = VM Network
```

**The fix I have below addresses this, but it is not that flexible**. The ideal fix would be based on the `network_interface` that is provided in the `vsphere_virtual_machine` provider. If there are multiple network interfaces it would match against the label before selecting the ip address for the dynamic inventory.

Also, this can be set within terraform under the `vsphere_virtual_machine` provider:

```
resource "vsphere_virtual_machine" "queue1" {
  network_interface {
    label = "VM Network"
  }
}
```

Not sure if this helps, but hope is sheds some light. I would be most worried about breaking an older version of vSphere as I do not have older versions to test with.