### PR TITLE
Correctly provides the public IP when it gets assigned by GCP

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -409,8 +409,8 @@ def gce_host(resource, module_name):
 
     try:
         attrs.update({
-            'ansible_ssh_host': interfaces[0]['access_config'][0]['nat_ip'],
-            'public_ipv4': interfaces[0]['access_config'][0]['nat_ip'],
+            'ansible_ssh_host': interfaces[0]['access_config'][0]['nat_ip'] or interfaces[0]['access_config'][0]['assigned_nat_ip'],
+            'public_ipv4': interfaces[0]['access_config'][0]['nat_ip'] or interfaces[0]['access_config'][0]['assigned_nat_ip'],
             'private_ipv4': interfaces[0]['address'],
             'publicly_routable': True,
         })


### PR DESCRIPTION
Current version generates an empty `ansible_ssh_host` for some of my public facing hosts, this fixes the issue.