### PR TITLE
Add Drone CI configuration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,15 @@
+cache:
+  mount:
+    - .git
+
+build:
+  image: $$IMAGE
+  commands:
+    - pip install -r requirements.txt
+    - py.test
+
+matrix:
+    IMAGE:
+        - python:2.7
+        - pypy:2
+


### PR DESCRIPTION
Since we have trouble enabling Travis builds on CiscoCloud repos, here's a Drone config for CI! Testing with python2 and pypy, just like the current Travis config. 