### PR TITLE
Change MI -> Mantl

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Or in a playbook:
 ## Releases
 
 `terraform.py` is with matching versions of
-[microservices-infrastructure](https://github.com/CiscoCloud/microservices-infrastructure).
-Run `terraform.py --version` to report the current version.
+[mantl](https://github.com/CiscoCloud/mantl). Run `terraform.py --version` to
+report the current version.
 
 ## Adding a new provider
 
@@ -72,7 +72,7 @@ calls them.) A parser is a function that takes a resource (a dictionary
 processed from JSON) and outputs a tuple of `(name, attributes, groups)`. The
 parser should be decorated with the `parses` decorator, which takes the name of
 the resource (EG `aws_instance`). It should also be decorated with
-`calculate_mi_vars`.
+`calculate_mantl_vars`.
 
 As a guideline, `terraform.py` should require no resources outside the Python
 standard distribution so it can just be copied in wherever it's needed.
@@ -120,13 +120,13 @@ a list. Given keys like this and the prefix "keys":
 
     ...
     "tags.#": "2",
-    "tags.2783239913": "mi",
+    "tags.2783239913": "mantl",
     "tags.3990563915": "control",
     ...
 
 `parse_list` would return this:
 
-    ["mi", "control"]
+    ["mantl", "control"]
 
 ## License
 

--- a/terraform.py
+++ b/terraform.py
@@ -75,7 +75,7 @@ def parses(prefix):
     return inner
 
 
-def calculate_mi_vars(func):
+def calculate_mantl_vars(func):
     """calculate Mantl vars"""
 
     @wraps(func)
@@ -139,7 +139,7 @@ def parse_bool(string_form):
 
 
 @parses('digitalocean_droplet')
-@calculate_mi_vars
+@calculate_mantl_vars
 def digitalocean_host(resource, tfvars=None):
     raw_attrs = resource['primary']['attributes']
     name = raw_attrs['name']
@@ -189,7 +189,7 @@ def digitalocean_host(resource, tfvars=None):
 
 
 @parses('softlayer_virtualserver')
-@calculate_mi_vars
+@calculate_mantl_vars
 def softlayer_host(resource, module_name):
     raw_attrs = resource['primary']['attributes']
     name = raw_attrs['name']
@@ -227,7 +227,7 @@ def softlayer_host(resource, module_name):
 
 
 @parses('openstack_compute_instance_v2')
-@calculate_mi_vars
+@calculate_mantl_vars
 def openstack_host(resource, module_name):
     raw_attrs = resource['primary']['attributes']
     name = raw_attrs['name']
@@ -295,7 +295,7 @@ def openstack_host(resource, module_name):
 
 
 @parses('aws_instance')
-@calculate_mi_vars
+@calculate_mantl_vars
 def aws_host(resource, module_name):
     name = resource['primary']['attributes']['tags.Name']
     raw_attrs = resource['primary']['attributes']
@@ -364,7 +364,7 @@ def aws_host(resource, module_name):
 
 
 @parses('google_compute_instance')
-@calculate_mi_vars
+@calculate_mantl_vars
 def gce_host(resource, module_name):
     name = resource['primary']['id']
     raw_attrs = resource['primary']['attributes']
@@ -439,7 +439,7 @@ def gce_host(resource, module_name):
 
 
 @parses('vsphere_virtual_machine')
-@calculate_mi_vars
+@calculate_mantl_vars
 def vsphere_host(resource, module_name):
     raw_attrs = resource['primary']['attributes']
     network_attrs = parse_dict(raw_attrs, 'network_interface')
@@ -481,7 +481,7 @@ def vsphere_host(resource, module_name):
     return name, attrs, groups
 
 @parses('azure_instance')
-@calculate_mi_vars
+@calculate_mantl_vars
 def azure_host(resource, module_name):
     name = resource['primary']['attributes']['name']
     raw_attrs = resource['primary']['attributes']
@@ -512,19 +512,19 @@ def azure_host(resource, module_name):
         'ansible_ssh_host': raw_attrs['vip_address'],
     }
 
-    # attrs specific to microservices-infrastructure
+    # attrs specific to mantl
     attrs.update({
         'consul_dc': attrs['location'].lower().replace(" ", "-"),
         'role': attrs['description']
     })
 
-    # groups specific to microservices-infrastructure
+    # groups specific to mantl
     groups.extend(['azure_image=' + attrs['image'],
                    'azure_location=' + attrs['location'].lower().replace(" ", "-"),
                    'azure_username=' + attrs['username'],
                    'azure_security_group=' + attrs['security_group']])
 
-    # groups specific to microservices-infrastructure
+    # groups specific to mantl
     groups.append('role=' + attrs['role'])
     groups.append('dc=' + attrs['consul_dc'])
 

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -17,7 +17,7 @@ def gce_resource():
             "id": "mi-control-01",
             "attributes": {
                 "can_ip_forward": "false",
-                "description": "microservices-infrastructure control node #01",
+                "description": "mantl control node #01",
                 "disk.#": "1",
                 "disk.0.auto_delete": "true",
                 "disk.0.device_name": "",
@@ -40,7 +40,7 @@ def gce_resource():
                 "network_interface.0.access_config.0.nat_ip": "104.197.63.156",
                 "network_interface.0.address": "10.0.237.130",
                 "network_interface.0.name": "nic0",
-                "network_interface.0.network": "microservices-infrastructure",
+                "network_interface.0.network": "mantl",
                 "self_link":
                 "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/instances/mi-control-01",
                 "service_account.#": "0",
@@ -78,7 +78,7 @@ def test_name(gce_resource, gce_host):
      'sshKeys': 'fake ssh key', },
     'network': [],
     'network_interface': [{
-        'network': 'microservices-infrastructure',
+        'network': 'mantl',
         'access_config': [{'nat_ip': '104.197.63.156'}],
         'address': '10.0.237.130',
         'name': 'nic0'


### PR DESCRIPTION
The [main repo](https://github.com/CiscoCloud/mantl) has done it's name change, now this repo needs to as well. :)