### PR TITLE
Export right private address for DigitalOcean.

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -161,7 +161,8 @@ def digitalocean_host(resource, tfvars=None):
         'ansible_ssh_user': 'root',  # it's always "root" on DO
         # generic
         'public_ipv4': raw_attrs['ipv4_address'],
-        'private_ipv4': raw_attrs['ipv4_address'],
+        'private_ipv4': raw_attrs.get('ipv4_address_private',
+                                      raw_attrs['ipv4_address']),
         'provider': 'digitalocean',
     }
 


### PR DESCRIPTION
If private networking is enabled while creating a DigitalOcean droplet, private ip address is exported in ipv4_address_private.
I also kept the old use-public-address-as-private-address method as a fallback to keep it backward compatible in case of private networking not chosen when creating the droplet.