### PR TITLE
Adding Azurerm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ reading Terraform's `.tfstate` files. It currently supports:
  - Openstack ([`openstack_compute_instance_v2`'](https://www.terraform.io/docs/providers/openstack/r/compute_instance_v2.html))
  - DigitalOcean ([`digitalocean_droplet`](http://terraform.io/docs/providers/do/r/droplet.html))
  - Azure ([`azure_instance`](https://www.terraform.io/docs/providers/azure/r/instance.html))
+ - AzureRM ([`azure_virtual_machine`](https://www.terraform.io/docs/providers/azurerm/r/virtual_machine.html))
  - VMware vSphere ([`vsphere_virtual_machine`](https://www.terraform.io/docs/providers/vsphere/r/virtual_machine.html))
  - CenturyLinkCloud ([`clc_server`](https://www.terraform.io/docs/providers/clc/r/server.html))
  - SoftLayer ([`softlayer_virtualserver`](https://github.com/finn-no/terraform-provider-softlayer)) (Unofficial)
@@ -43,10 +44,18 @@ place on your filesystem should do the trick.
 Make sure that you've annotated your resources with "tags" that correspond to the sshUser for the machine.
 
 Example, for EC2 resources, add a [tags](https://www.terraform.io/docs/providers/aws/r/instance.html#tags) entry of "sshUser" equal to "ec2-user":
-	
+
 	tags {
       Name = "cheese"
       sshUser = "ec2-user"
+    }
+
+Example, for AzureRM resources, add [tags](https://www.terraform.io/docs/providers/azurerm/r/virtual_machine.html#tags) entries for ssh_user, role and ssh_ip based on the [Network Interface](https://www.terraform.io/docs/providers/azurerm/r/network_interface.html) you plan to access the instance from:
+
+    tags {
+        ssh_user = "azurerm-user"
+        ssh_ip = "${azurerm_network_interface.my_nic.private_ip_address}"
+        role = "myrole"
     }
 
 Next, specify `terraform.py` as an inventory source for any Ansible command. For

--- a/terraform.py
+++ b/terraform.py
@@ -550,6 +550,28 @@ def vsphere_host(resource, module_name):
 
     return name, attrs, groups
 
+
+@parses('azurerm_virtual_machine')
+@calculate_mantl_vars
+def azure_host(resource, module_name):
+    name = resource['primary']['attributes']['name']
+    raw_attrs = resource['primary']['attributes']
+
+    groups = []
+
+    attrs = {
+        'id': raw_attrs['id'],
+        'name': raw_attrs['name'],
+        # ansible
+        'ansible_ssh_port': 22,
+        'ansible_ssh_user': raw_attrs.get('tags.ssh_user', ''),
+        'ansible_ssh_host': raw_attrs.get('tags.ssh_ip', ''),
+    }
+
+    groups.append('role=' + raw_attrs.get('tags.role', ''))
+
+    return name, attrs, groups
+
 @parses('azure_instance')
 @calculate_mantl_vars
 def azure_host(resource, module_name):

--- a/terraform.py
+++ b/terraform.py
@@ -553,7 +553,7 @@ def vsphere_host(resource, module_name):
 
 @parses('azurerm_virtual_machine')
 @calculate_mantl_vars
-def azure_host(resource, module_name):
+def azurerm_host(resource, module_name):
     name = resource['primary']['attributes']['name']
     raw_attrs = resource['primary']['attributes']
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from copy import deepcopy
 
 
 @pytest.fixture
@@ -100,6 +101,12 @@ def test_attrs(aws_resource, aws_host, attr, should):
     _, attrs, _ = aws_host(aws_resource, 'module_name')
     assert attr in attrs
     assert attrs[attr] == should
+
+def test_private_ip_default(aws_resource, aws_host):
+    private_resource = deepcopy(aws_resource)
+    private_resource["primary"]["attributes"]["public_ip"] = ""
+    _, attrs, _ = aws_host(private_resource, 'module_name')
+    assert attrs['ansible_ssh_host'] == '10.0.152.191'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_azurerm.py
+++ b/tests/test_azurerm.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+
+@pytest.fixture
+def azurerm_host():
+    from terraform import azurerm_host
+    return azurerm_host
+
+
+@pytest.fixture
+def azurerm_resource():
+    return {
+        "type": "azurerm_virtual_machine",
+        "depends_on": [
+            "azurerm_network_interface.nic"
+        ],
+        "primary": {
+            "id": "/subscriptions/mysubguid/resourceGroups/terraformdemo/providers/Microsoft.Compute/virtualMachines/terraformdemo",
+            "attributes": {
+                "delete_data_disks_on_termination": "false",
+                "delete_os_disk_on_termination": "false",
+                "id": "/subscriptions/mysubguid/resourceGroups/terraformdemo/providers/Microsoft.Compute/virtualMachines/terraformdemo",
+                "location": "ukwest",
+                "name": "terraformdemo",
+                "network_interface_ids.#": "1",
+                "network_interface_ids.3454837957": "/subscriptions/mysubguid/resourceGroups/terraformdemo/providers/Microsoft.Network/networkInterfaces/terraformdemo_nic0",
+                "os_profile.#": "1",
+                "os_profile.3552212945.admin_password": "",
+                "os_profile.3552212945.admin_username": "terraformdemoadmin",
+                "os_profile.3552212945.computer_name": "terraformdemo",
+                "os_profile.3552212945.custom_data": "",
+                "os_profile_linux_config.#": "1",
+                "os_profile_linux_config.2972667452.disable_password_authentication": "false",
+                "os_profile_linux_config.2972667452.ssh_keys.#": "2",
+                "os_profile_linux_config.2972667452.ssh_keys.1.key_data": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCuXxPfC3b1/ps99+b7qGUVtrW+hvqoUqc/90f9/QnUa21mnDsOtC3TYgr318az6GFXwp3fdOVQKrieAjMCJjfyAZICxrEjpSTCEOh+qRaUJxRy+Mn2DqrlMB32erNAu68Z837VSyGvkPxFrhLXZryuTBvGK6/WbI6uS4Nxpglre1EDeru/8QChjDA+RN8A06Td0MMv3TMJCf0iWaRrlDEbdvi6Ceq30iJZ655TJ4h3fHIn8oONdlJTLmqliUPgg0WvhQAZPFQWyYAzfLaEix+BvwLXJSRCm31zSTmxmYVkjHJDr4UTUKMTEhW1GlTxOqc6oRrH8d07wrCjf70v1op1\n",
+                "os_profile_linux_config.2972667452.ssh_keys.1.path": "/home/terraformdemoadmin/.ssh/authorized_keys",
+                "os_profile_secrets.#": "0",
+                "resource_group_name": "terraformdemo",
+                "storage_data_disk.#": "0",
+                "storage_image_reference.#": "1",
+                "storage_image_reference.1222634046.offer": "UbuntuServer",
+                "storage_image_reference.1222634046.publisher": "Canonical",
+                "storage_image_reference.1222634046.sku": "16.04-LTS",
+                "storage_image_reference.1222634046.version": "latest",
+                "storage_os_disk.#": "1",
+                "storage_os_disk.2197840352.caching": "ReadWrite",
+                "storage_os_disk.2197840352.create_option": "FromImage",
+                "storage_os_disk.2197840352.disk_size_gb": "0",
+                "storage_os_disk.2197840352.image_uri": "",
+                "storage_os_disk.2197840352.name": "terraformdemo_os",
+                "storage_os_disk.2197840352.os_type": "",
+                "storage_os_disk.2197840352.vhd_uri": "https://terraformdemo.blob.core.windows.net/vhds/terraformdemo_disk.vhd",
+                "tags.%": "5",
+                "tags.environment": "terraformdemo",
+                "tags.os": "ubuntu",
+                "tags.role": "myrole",
+                "tags.ssh_ip": "10.10.0.1",
+                "tags.ssh_user": "terraformdemoadmin",
+                "vm_size": "Standard_D2_v2"
+            },
+        },
+    }
+
+
+def test_name(azurerm_resource, azurerm_host):
+    name, _, _ = azurerm_host(azurerm_resource, '')
+    assert name == 'terraformdemo'
+
+@pytest.mark.parametrize('attr,should', {
+        "id": "/subscriptions/mysubguid/resourceGroups/terraformdemo/providers/Microsoft.Compute/virtualMachines/terraformdemo",
+        "name": "terraformdemo",
+        "ansible_ssh_port": 22,
+        "ansible_ssh_user": "terraformdemoadmin",
+        "ansible_ssh_host": "10.10.0.1",
+}.items())
+def test_attrs(azurerm_resource, azurerm_host, attr, should):
+    _, attrs, _ = azurerm_host(azurerm_resource, 'ukwest')
+    assert attr in attrs
+    assert attrs[attr] == should
+
+
+@pytest.mark.parametrize('group', [
+        'role=myrole'
+])
+def test_groups(azurerm_resource, azurerm_host, group):
+    _, _, groups = azurerm_host(azurerm_resource, 'ukwest')
+    assert group in groups


### PR DESCRIPTION
Azurerm support requires passing details via tags as the networking values required are held on a different resource. Not as clean as I'd like but hopefully useful to others.